### PR TITLE
Issue#3 create event code generator

### DIFF
--- a/WhenWorksWeb/Program.cs
+++ b/WhenWorksWeb/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using WhenWorksWeb.Data;
 using WhenWorksWeb.Models;
+using WhenWorksWeb.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +15,10 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddDefaultIdentity<ApplicationUser>(IdentityConfiguration.Configure)
     .AddRoles<IdentityRole>() // Add role support to Identity
     .AddEntityFrameworkStores<ApplicationDbContext>();
+
+// Register the EventCodeGenerator as a scoped service, so it can be injected into controllers and other services.
+builder.Services.AddScoped<EventCodeGenerator>();
+
 builder.Services.AddControllersWithViews();
 
 var app = builder.Build();

--- a/WhenWorksWeb/Services/EventCodeGenerator.cs
+++ b/WhenWorksWeb/Services/EventCodeGenerator.cs
@@ -1,6 +1,65 @@
-﻿namespace WhenWorksWeb.Services
+﻿using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
+using WhenWorksWeb.Data;
+
+namespace WhenWorksWeb.Services
 {
     public class EventCodeGenerator
     {
+        // The length of the event code.
+        private const int CodeLength = 6;
+
+        // The maximum number of attempts to generate a unique code before giving up.
+        // This is a safeguard against infinite loops in the unlikely event of many collisions.
+        private const int MaxAttempts = 50;
+
+        // A custom alphabet that excludes easily confused characters (A, E, I, L, O, U, 0, 1) to improve readability of codes.
+        private static readonly char[] Alphabet = "BCDFGHJKMNPQRSTVWXYZ23456789".ToCharArray();
+
+        private readonly ApplicationDbContext _dbContext;
+
+        public EventCodeGenerator(ApplicationDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        /// <summary>
+        /// Asynchronously generates a unique event code that does not already exist in the database.
+        /// </summary>
+        /// <remarks>This method attempts to generate a unique code by checking for collisions in the
+        /// database. The number of attempts is limited by an internal maximum. If all attempts result in a collision,
+        /// the method throws an exception.</remarks>
+        public async Task<string> GenerateUniqueCodeAsync(CancellationToken cancellationToken = default)
+        {
+            for (var attempt = 0; attempt < MaxAttempts; attempt++)
+            {
+                var code = GenerateCode();
+
+                Boolean exists = await _dbContext.Events
+                    .AnyAsync(e => e.Code == code, cancellationToken);
+
+                if (!exists)
+                {
+                    return code;
+                }
+            }
+
+            throw new InvalidOperationException("Unable to generate a unique event code.");
+        }
+
+        /// <summary>
+        /// Generates a random 6 character code using a predefined alphabet.
+        /// </summary>
+        private static string GenerateCode()
+        {
+            Span<char> chars = stackalloc char[CodeLength];
+
+            for (var i = 0; i < CodeLength; i++)
+            {
+                chars[i] = Alphabet[RandomNumberGenerator.GetInt32(Alphabet.Length)];
+            }
+
+            return new string(chars);
+        }
     }
 }

--- a/WhenWorksWeb/Services/EventCodeGenerator.cs
+++ b/WhenWorksWeb/Services/EventCodeGenerator.cs
@@ -1,0 +1,6 @@
+﻿namespace WhenWorksWeb.Services
+{
+    public class EventCodeGenerator
+    {
+    }
+}

--- a/WhenWorksWeb/Services/EventCodeGenerator.cs
+++ b/WhenWorksWeb/Services/EventCodeGenerator.cs
@@ -4,6 +4,9 @@ using WhenWorksWeb.Data;
 
 namespace WhenWorksWeb.Services
 {
+    /// <summary>
+    /// Provides functionality to generate unique, human-readable event codes that do not already exist in the database.
+    /// </summary>
     public class EventCodeGenerator
     {
         // The length of the event code.


### PR DESCRIPTION
Closes #3

This pull request introduces a new service for generating unique, human-readable event codes and registers it for dependency injection. The main goal is to provide a reliable and readable way to generate event codes that do not conflict with existing ones in the database.

**New Event Code Generation Service:**

* Added the `EventCodeGenerator` service in `WhenWorksWeb/Services/EventCodeGenerator.cs`, which generates unique, collision-resistant, 6-character event codes using a custom alphabet to improve readability and avoid ambiguous characters. The service checks for code uniqueness in the database and limits the number of attempts to avoid infinite loops.

**Dependency Injection Setup:**

* Registered `EventCodeGenerator` as a scoped service in the DI container within `Program.cs`, making it available for injection into controllers and other services.
* Added the required `using WhenWorksWeb.Services;` statement to `Program.cs` to support the new service registration.