### PR TITLE
Remove Privacy link from navigation bar

### DIFF
--- a/WhenWorksWeb/Views/Shared/_Layout.cshtml
+++ b/WhenWorksWeb/Views/Shared/_Layout.cshtml
@@ -23,9 +23,6 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
-                        </li>
                         @if (User.IsInRole("Admin"))
                         {
                             <li class="nav-item">


### PR DESCRIPTION
The "Privacy" navigation link was removed from the navigation bar in the _Layout.cshtml file to simplify the navigation options.