### PR TITLE
Refactor registration UI; add color picker

### DIFF
--- a/WhenWorksWeb/Areas/Identity/Pages/Account/Register.cshtml
+++ b/WhenWorksWeb/Areas/Identity/Pages/Account/Register.cshtml
@@ -4,54 +4,80 @@
     ViewData["Title"] = "Register";
 }
 
+<!-- Page heading -->
 <h1>@ViewData["Title"]</h1>
 
 <div class="row">
     <div class="col-md-4">
+        <!-- Registration form -->
         <form id="registerForm" asp-route-returnUrl="@Model.ReturnUrl" method="post">
             <h2>Create a new account.</h2>
             <hr />
+
+            <!-- Validation summary for form-wide errors -->
             <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+
+            <!-- Username input -->
             <div class="form-floating mb-3">
                 <input asp-for="Input.UserName" class="form-control" autocomplete="username" aria-required="true" placeholder="Your_UserName" />
                 <label asp-for="Input.UserName">User Name</label>
                 <span asp-validation-for="Input.UserName" class="text-danger"></span>
             </div>
+
+            <!-- Email input -->
             <div class="form-floating mb-3">
                 <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
                 <label asp-for="Input.Email">Email</label>
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.DisplayName" class="form-control" autocomplete="nickname" aria-required="true" placeholder="Your Nickname" />
-                <label asp-for="Input.DisplayName">Display Name</label>
-                <span asp-validation-for="Input.DisplayName" class="text-danger"></span>
-            </div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.Color" class="form-control" autocomplete="off" aria-required="true" placeholder="FFFFFF" />
-                <label asp-for="Input.Color">Color</label>
-                <span asp-validation-for="Input.Color" class="text-danger"></span>
-            </div>
+
+            <!-- Password input -->
             <div class="form-floating mb-3">
                 <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
                 <label asp-for="Input.Password">Password</label>
                 <span asp-validation-for="Input.Password" class="text-danger"></span>
             </div>
+
+            <!-- Confirm password input -->
             <div class="form-floating mb-3">
                 <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
                 <label asp-for="Input.ConfirmPassword">Confirm Password</label>
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>
+
+            <!-- Display name input -->
+            <div class="form-floating mb-3">
+                <input asp-for="Input.DisplayName" class="form-control" autocomplete="nickname" aria-required="true" placeholder="Your Nickname" />
+                <label asp-for="Input.DisplayName">Display Name</label>
+                <span asp-validation-for="Input.DisplayName" class="text-danger"></span>
+            </div>
+
+            <!-- Color picker input that stores a hex value -->
+            <div class="mb-3 d-flex flex-column align-items-center">
+                <label class="form-label text-center" for="colorPicker">Color</label>
+                <input type="color"
+                       id="colorPicker"
+                       class="form-control form-control-color mx-auto"
+                       value="#@Model.Input.Color" />
+                <input asp-for="Input.Color" type="hidden" id="Input_Color" />
+                <span asp-validation-for="Input.Color" class="text-danger text-center"></span>
+            </div>
+
+            <!-- Submit button -->
             <button id="registerSubmit" type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
         </form>
     </div>
+
     <div class="col-md-6 col-md-offset-2">
+        <!-- External login section -->
         <section>
             <h3>Use another service to register.</h3>
             <hr />
+
             @{
                 if ((Model.ExternalLogins?.Count ?? 0) == 0)
                 {
+                    <!-- No external authentication providers configured -->
                     <div>
                         <p>
                             There are no external authentication services configured. See this <a href="https://go.microsoft.com/fwlink/?LinkID=532715">article
@@ -61,6 +87,7 @@
                 }
                 else
                 {
+                    <!-- Render buttons for each external authentication provider -->
                     <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post" class="form-horizontal">
                         <div>
                             <p>
@@ -78,5 +105,25 @@
 </div>
 
 @section Scripts {
+    <!-- Client-side validation scripts -->
     <partial name="_ValidationScriptsPartial" />
+
+    <!-- Synchronizes the visible color picker with the hidden posted value -->
+    <script>
+        const form = document.getElementById('registerForm');
+        const colorPicker = document.getElementById('colorPicker');
+        const colorHidden = document.getElementById('Input_Color');
+
+        function syncColor() {
+            colorHidden.value = colorPicker.value.replace('#', '');
+        }
+
+        colorPicker.addEventListener('input', syncColor);
+
+        form.addEventListener('submit', () => {
+            syncColor();
+        });
+
+        syncColor();
+    </script>
 }

--- a/WhenWorksWeb/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/WhenWorksWeb/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -100,6 +100,8 @@ namespace WhenWorksWeb.Areas.Identity.Pages.Account
 
             /// <summary>
             /// Stores a hexadecimal color code (without the '#' symbol) that represents the user's preferred personal color for use in events.
+            /// Has a default value of "ff66c4" (a shade of pink) to ensure that users have a color assigned even if they don't specify one
+            /// during registration.
             /// </summary>
             [Required]
             [RegularExpression(@"^[A-Fa-f0-9]{6}$", ErrorMessage = "The {0} must be a valid 6-character hexadecimal color code.")]
@@ -126,17 +128,44 @@ namespace WhenWorksWeb.Areas.Identity.Pages.Account
             public string ConfirmPassword { get; set; }
         }
 
-
+        /// <summary>
+        /// This method is called when the registration page is accessed via a GET request. It initializes the Input model 
+        /// with a default color value and retrieves the list of external authentication schemes to display on the registration page. 
+        /// The returnUrl parameter is used to redirect the user after successful registration.
+        /// </summary>
+        /// <param name="returnUrl"></param>
+        /// <returns></returns>
         public async Task OnGetAsync(string returnUrl = null)
         {
+            // Set the return URL to redirect the user after successful registration
             ReturnUrl = returnUrl;
+
+            // Set a default color value for the registration form
+            Input = new InputModel
+            {
+                Color = "ff66c4"
+            };
+
+            // Retrieve the list of external authentication schemes (e.g., Google, Facebook) to display on the registration page
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
         }
 
+        /// <summary>
+        /// This method is called when the registration form is submitted via a POST request. It validates the input, creates a 
+        /// new user with the provided information, and handles the registration process. If the registration is successful, 
+        /// it sends a confirmation email to the user and either redirects to a confirmation page or signs the user in directly 
+        /// based on the application's configuration. If there are errors during registration, it redisplays the form with error 
+        /// messages.
+        /// </summary>
         public async Task<IActionResult> OnPostAsync(string returnUrl = null)
         {
+            // Set the return URL to redirect the user after successful registration
             returnUrl ??= Url.Content("~/");
+
+            // Retrieve the list of external authentication schemes (e.g., Google, Facebook) to display on the registration page
+            // in case of validation failure
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+
             if (ModelState.IsValid)
             {
                 var user = CreateUser();
@@ -150,6 +179,8 @@ namespace WhenWorksWeb.Areas.Identity.Pages.Account
                 await _emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
                 var result = await _userManager.CreateAsync(user, Input.Password);
 
+                // If the user creation is successful, log the event and send a confirmation email.
+                // Depending on the application's configuration, either redirect to a confirmation page or sign the user in directly.
                 if (result.Succeeded)
                 {
                     _logger.LogInformation("User created a new account with password.");
@@ -166,16 +197,19 @@ namespace WhenWorksWeb.Areas.Identity.Pages.Account
                     await _emailSender.SendEmailAsync(Input.Email, "Confirm your email",
                         $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
 
+                    // If the application requires confirmed accounts, redirect to the confirmation page.
                     if (_userManager.Options.SignIn.RequireConfirmedAccount)
                     {
                         return RedirectToPage("RegisterConfirmation", new { email = Input.Email, returnUrl = returnUrl });
                     }
+                    // If account confirmation is not required, sign the user in directly and redirect to the return URL.
                     else
                     {
                         await _signInManager.SignInAsync(user, isPersistent: false);
                         return LocalRedirect(returnUrl);
                     }
                 }
+                // If there are errors during user creation, add them to the ModelState to display on the registration form.
                 foreach (var error in result.Errors)
                 {
                     ModelState.AddModelError(string.Empty, error.Description);
@@ -186,6 +220,11 @@ namespace WhenWorksWeb.Areas.Identity.Pages.Account
             return Page();
         }
 
+        /// <summary>
+        /// This method creates a new instance of the ApplicationUser class. It uses Activator.CreateInstance to create the instance, 
+        /// which requires that the ApplicationUser class has a parameterless constructor and is not abstract. If the instance cannot
+        /// be created, it throws an InvalidOperationException with a message indicating the issue and suggesting how to resolve it.
+        /// </summary>
         private ApplicationUser CreateUser()
         {
             try
@@ -200,6 +239,12 @@ namespace WhenWorksWeb.Areas.Identity.Pages.Account
             }
         }
 
+        /// <summary>
+        /// This method retrieves the IUserEmailStore implementation from the user store. It checks if the user manager supports 
+        /// user email, and if not, it throws a NotSupportedException indicating that the default UI requires a user store with 
+        /// email support. If the user store does support email, it casts the user store to IUserEmailStore<ApplicationUser> and 
+        /// returns it for use in managing user email addresses during registration.
+        /// </summary>
         private IUserEmailStore<ApplicationUser> GetEmailStore()
         {
             if (!_userManager.SupportsUserEmail)


### PR DESCRIPTION
Closes #27

This pull request improves the user registration experience by enhancing the registration form's usability, especially around color selection. The most significant changes are the addition of a user-friendly color picker, setting a sensible default color, and extensive code comments to clarify registration logic.

**Frontend improvements to registration form:**

* Replaced the plain color input with a visual color picker and synchronized it with a hidden field to store the hex color value (without the `#`), ensuring the color is correctly submitted. Added descriptive comments and improved the layout for better user experience. [[1]](diffhunk://#diff-36d957a94e9aba84cdde5b3d41790569d3946636c40e3c976f0b8b3c04d73c0eR7-R80) [[2]](diffhunk://#diff-36d957a94e9aba84cdde5b3d41790569d3946636c40e3c976f0b8b3c04d73c0eR108-R128)

**Backend improvements and documentation:**

* Set a default color value (`ff66c4`, a shade of pink) for new users during registration if they do not select one, ensuring every user has a color assigned. [[1]](diffhunk://#diff-da2c8353a780fb4affcda52d5751fd65b83676e54a1f18ea60f67bc84adb84b0R103-R104) [[2]](diffhunk://#diff-da2c8353a780fb4affcda52d5751fd65b83676e54a1f18ea60f67bc84adb84b0L129-R168)