### PR TITLE
Issue#36 add my events page

### DIFF
--- a/WhenWorksWeb/Controllers/MyEventsController.cs
+++ b/WhenWorksWeb/Controllers/MyEventsController.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using WhenWorksWeb.Common;
+using WhenWorksWeb.Data;
+using WhenWorksWeb.Models;
+
+namespace WhenWorksWeb.Controllers;
+
+/// <summary>
+/// Provides access to the My Events page for authenticated users.
+/// </summary>
+[Authorize]
+public class MyEventsController : Controller
+{
+    private readonly ApplicationDbContext _db;
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public MyEventsController(ApplicationDbContext db, UserManager<ApplicationUser> userManager)
+    {
+        _db = db;
+        _userManager = userManager;
+    }
+
+    /// <summary>
+    /// This action retrieves the list of events the current user has joined and displays them on the My Events page. 
+    /// The events are ordered alphabetically by title and then by code. Each event's emoji is also included for display. 
+    /// If the user is not authenticated, they will be challenged to log in.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpGet]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var currentUser = await _userManager.GetUserAsync(User);
+        if (currentUser is null)
+        {
+            return Challenge();
+        }
+
+        // Load the user's joined events through Participant records.
+        // Event.Settings is included so the emoji can be displayed without extra queries.
+        var participants = await _db.Participants
+            .AsNoTracking()
+            .Where(p => p.UserId == currentUser.Id)
+            .Include(p => p.Event)
+                .ThenInclude(e => e.Settings)
+            .ToListAsync(cancellationToken);
+
+        var viewModel = participants
+            .GroupBy(p => p.EventId)
+            .Select(group => group.First())
+            .OrderBy(p => p.Event.Title)
+            .ThenBy(p => p.Event.Code)
+            .Select(participant => new MyEventViewModel
+            {
+                Code = participant.Event.Code,
+                Title = participant.Event.Title,
+                Emoji = participant.Event.Settings?.Emoji ?? ModelConstants.DefaultEventEmoji,
+                SignInUrl = Url.RouteUrl("EventSignIn", new { code = participant.Event.Code }) ?? string.Empty
+            })
+            .ToList();
+
+        return View(viewModel);
+    }
+}

--- a/WhenWorksWeb/Models/MyEventViewModel.cs
+++ b/WhenWorksWeb/Models/MyEventViewModel.cs
@@ -1,0 +1,27 @@
+﻿namespace WhenWorksWeb.Models;
+
+/// <summary>
+/// Represents a single event row on the My Events page.
+/// </summary>
+public sealed class MyEventViewModel
+{
+    /// <summary>
+    /// The unique event code.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>
+    /// The event title.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// The emoji representing the event.
+    /// </summary>
+    public required string Emoji { get; init; }
+
+    /// <summary>
+    /// The URL used to send the user to the existing event sign-in page.
+    /// </summary>
+    public required string SignInUrl { get; init; }
+}

--- a/WhenWorksWeb/Views/MyEvents/Index.cshtml
+++ b/WhenWorksWeb/Views/MyEvents/Index.cshtml
@@ -8,7 +8,7 @@
 <!-- Page container -->
 <div class="container py-4" style="max-width: 42rem;">
     <!-- Page heading -->
-    <h1 class="h3 mb-3">My Events</h1>
+    <h1 class="h3 mb-3 text-center">My Events</h1>
 
     <!-- Empty state shown when the user has not joined any events -->
     @if (Model.Count == 0)
@@ -21,10 +21,6 @@
     {
         <!-- Event list card with a fixed-height scrolling interior -->
         <div class="card">
-            <!-- Card header that labels the section -->
-            <div class="card-header bg-body-tertiary">
-                <span class="fw-semibold">Joined Events</span>
-            </div>
 
             <!-- Scrollable container for the joined event list -->
             <div class="card-body p-0 overflow-auto" id="my-events-list" style="max-height: 21rem;">
@@ -39,9 +35,9 @@
                             <span class="fs-4">@myEvent.Emoji</span>
 
                             <!-- Event title and code -->
-                            <span class="flex-grow-1 text-start">
-                                <span class="d-block fw-semibold">@myEvent.Title</span>
-                                <small class="text-muted">Code: <strong>@myEvent.Code</strong></small>
+                            <span class="d-flex flex-row align-items-center gap-2 flex-grow-1 text-start text-break">
+                                <span class="fw-semibold flex-grow-1">@myEvent.Title</span>
+                                <small class="text-muted ms-auto flex-shrink-0"><strong>@myEvent.Code</strong></small>
                             </span>
                         </button>
                     }
@@ -50,7 +46,7 @@
         </div>
 
         <!-- GO button shown only after the user selects an event -->
-        <div class="mt-3 d-none" id="my-events-go-container">
+        <div class="mt-3 d-none text-center" id="my-events-go-container">
             <button type="button" class="btn btn-primary" id="my-events-go-button">GO!</button>
         </div>
     }

--- a/WhenWorksWeb/Views/MyEvents/Index.cshtml
+++ b/WhenWorksWeb/Views/MyEvents/Index.cshtml
@@ -1,0 +1,102 @@
+﻿@model IReadOnlyList<WhenWorksWeb.Models.MyEventViewModel>
+
+@* Displays the signed-in user's joined events, allows event selection, and routes the user to the event sign-in page. *@
+@{
+    ViewData["Title"] = "My Events";
+}
+
+<!-- Page container -->
+<div class="container py-4" style="max-width: 42rem;">
+    <!-- Page heading -->
+    <h1 class="h3 mb-3">My Events</h1>
+
+    <!-- Empty state shown when the user has not joined any events -->
+    @if (Model.Count == 0)
+    {
+        <div class="alert alert-info mb-0">
+            You have not joined any events yet.
+        </div>
+    }
+    else
+    {
+        <!-- Event list card with a fixed-height scrolling interior -->
+        <div class="card">
+            <!-- Card header that labels the section -->
+            <div class="card-header bg-body-tertiary">
+                <span class="fw-semibold">Joined Events</span>
+            </div>
+
+            <!-- Scrollable container for the joined event list -->
+            <div class="card-body p-0 overflow-auto" id="my-events-list" style="max-height: 21rem;">
+                <div class="list-group list-group-flush">
+                    @foreach (var myEvent in Model)
+                    {
+                        <!-- Clickable event row -->
+                        <button type="button"
+                                class="list-group-item list-group-item-action d-flex align-items-center gap-3 my-event-item"
+                                data-signin-url="@myEvent.SignInUrl">
+                            <!-- Event emoji -->
+                            <span class="fs-4">@myEvent.Emoji</span>
+
+                            <!-- Event title and code -->
+                            <span class="flex-grow-1 text-start">
+                                <span class="d-block fw-semibold">@myEvent.Title</span>
+                                <small class="text-muted">Code: <strong>@myEvent.Code</strong></small>
+                            </span>
+                        </button>
+                    }
+                </div>
+            </div>
+        </div>
+
+        <!-- GO button shown only after the user selects an event -->
+        <div class="mt-3 d-none" id="my-events-go-container">
+            <button type="button" class="btn btn-primary" id="my-events-go-button">GO!</button>
+        </div>
+    }
+</div>
+
+<!-- Client-side selection behavior for highlighting the chosen event and navigating to sign-in -->
+@section Scripts {
+    <script>
+        (function () {
+            const list = document.getElementById('my-events-list');
+            const goContainer = document.getElementById('my-events-go-container');
+            const goButton = document.getElementById('my-events-go-button');
+
+            if (!list || !goContainer || !goButton) {
+                return;
+            }
+
+            let selectedItem = null;
+
+            // Highlight the selected event and reveal the GO button
+            list.addEventListener('click', function (event) {
+                const item = event.target.closest('.my-event-item');
+                if (!item || !list.contains(item)) {
+                    return;
+                }
+
+                if (selectedItem) {
+                    selectedItem.classList.remove('selected');
+                }
+
+                selectedItem = item;
+                selectedItem.classList.add('selected');
+                goContainer.classList.remove('d-none');
+            });
+
+            // Navigate to the event sign-in page for the selected event
+            goButton.addEventListener('click', function () {
+                if (!selectedItem) {
+                    return;
+                }
+
+                const signInUrl = selectedItem.getAttribute('data-signin-url');
+                if (signInUrl) {
+                    window.location.href = signInUrl;
+                }
+            });
+        })();
+    </script>
+}

--- a/WhenWorksWeb/Views/Shared/_LoginPartial.cshtml
+++ b/WhenWorksWeb/Views/Shared/_LoginPartial.cshtml
@@ -2,12 +2,21 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
 
+@* Renders the navbar links for authentication state, including the My Events link for signed-in users. *@
 <ul class="navbar-nav">
 @if (SignInManager.IsSignedIn(User))
 {
+    <!-- Link to the authenticated user's joined events page -->
+    <li class="nav-item">
+        <a class="nav-link text-dark" asp-controller="MyEvents" asp-action="Index">My Events</a>
+    </li>
+
+    <!-- Greeting / account management link -->
     <li class="nav-item">
         <a  class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">Hello @User.Identity?.Name!</a>
     </li>
+
+    <!-- Logout form -->
     <li class="nav-item">
         <form  class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })">
             <button  type="submit" class="nav-link btn btn-link text-dark">Logout</button>
@@ -16,9 +25,12 @@
 }
 else
 {
+    <!-- Registration link for anonymous users -->
     <li class="nav-item">
         <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Register">Register</a>
     </li>
+
+    <!-- Login link for anonymous users -->
     <li class="nav-item">
         <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Login">Login</a>
     </li>


### PR DESCRIPTION
Closes #36

This pull request introduces a new "My Events" feature that allows authenticated users to view and navigate to the events they have joined. It adds a new controller, view model, and Razor page, and updates the navigation to include a link to this page for signed-in users.

**New "My Events" feature:**
- Adds a new page where authenticated users can see a list of their joined events, select one, and quickly navigate to its sign-in page.

---

**Backend/API changes:**
* Added `MyEventsController` with an authenticated `Index` action that loads the current user's joined events, including event emoji and sign-in URL, and passes them to the view.
* Introduced the `MyEventViewModel` class to represent each event row shown on the "My Events" page.

**Frontend/UI changes:**
* Created the `Views/MyEvents/Index.cshtml` Razor page to display the user's events, including client-side selection logic and navigation to the event sign-in page.
* Updated the shared login partial (`_LoginPartial.cshtml`) to add a "My Events" navbar link for authenticated users.
* Improved navbar for anonymous users by clarifying the registration and login links.* 